### PR TITLE
fe: feature: ブログカードコンポーネントの実装

### DIFF
--- a/src/component/BlogCard/index.module.css
+++ b/src/component/BlogCard/index.module.css
@@ -1,7 +1,7 @@
 .container {
   width: 100%;
   max-width: 720px;
-  background-color: #D9D9D9;
+  background-color: #d9d9d9;
   margin: 0 auto;
   padding: 40px;
   border-radius: 24px;
@@ -53,7 +53,7 @@
 .imageArea {
   width: 100%;
   aspect-ratio: 2 / 1;
-  background-color: #9797979C;
+  background-color: #9797979c;
   border: 1px solid #000;
   margin-bottom: 24px;
   position: relative;

--- a/src/component/BlogCard/index.tsx
+++ b/src/component/BlogCard/index.tsx
@@ -2,7 +2,6 @@ import styles from "./index.module.css";
 
 type Props = {
   title: string;
-  category?: string;
   imageUrl?: string;
   content: string;
   authorIconUrl?: string;
@@ -16,12 +15,9 @@ const BlogCard = ({ title, imageUrl, content, authorIconUrl }: Props) => {
         <h1 className={styles.title}>{title}</h1>
         <div className={styles.authorIcon}>
           {authorIconUrl ? (
+            // Imageタグを使うべきだが、next.config.jsの設定回避のため一時的にimgタグを使用
             /* eslint-disable-next-line @next/next/no-img-element */
-            <img 
-              src={authorIconUrl} 
-              alt="Author" 
-              className={styles.iconImage}
-            />
+            <img src={authorIconUrl} alt="Author" className={styles.iconImage} />
           ) : (
             <span className={styles.defaultIcon}>👤</span>
           )}
@@ -31,12 +27,9 @@ const BlogCard = ({ title, imageUrl, content, authorIconUrl }: Props) => {
       {/* 画像エリア */}
       <div className={styles.imageArea}>
         {imageUrl ? (
+          // Imageタグを使うべきだが、next.config.jsの設定回避のため一時的にimgタグを使用
           /* eslint-disable-next-line @next/next/no-img-element */
-          <img 
-            src={imageUrl} 
-            alt={title} 
-            className={styles.image} 
-          />
+          <img src={imageUrl} alt={title} className={styles.image} />
         ) : (
           <div className={styles.noImage}></div>
         )}


### PR DESCRIPTION
close #21
以下の作成を行いました。
・ブログカードコンポーネント（src/component/BlogCard/index.tsx, index.module.css）
imgタグの使用について: 
  現在 `next.config.js` へのドメイン設定を行っていないため、一時的に `next/image` ではなく `<img>` タグを使用しています。
  Lintエラーを回避するためのコメントと、意図をコード内に記載しています。

<img width="198" height="101" alt="スクリーンショット 2026-02-05 095034" src="https://github.com/user-attachments/assets/a2a909db-9b88-425e-b8ca-10db1a8812ac" />

ご確認のほど、よろしくお願い申し上げます。
