### PR TITLE
[fe/feature] ログイン認証ロジック実装

### DIFF
--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -3,7 +3,11 @@
 import { createClient } from "@/libs/supabase/server";
 import { redirect } from "next/navigation";
 
-export async function login(formData: FormData) {
+export type ActionState = {
+  message: string;
+};
+
+export async function login(prevState: ActionState | null, formData: FormData) {
   const supabase = await createClient();
 
   // フォームから入力値を取得
@@ -17,8 +21,11 @@ export async function login(formData: FormData) {
   });
 
   if (error) {
-    // 認証失敗時はエラーパラメータを付与してログイン画面へリダイレクト
-    redirect("/login?error=auth-failed");
+    if (error.code === "invalid_credentials") {
+      return { message: "メールアドレスとパスワードをご確認ください。" };
+    } else {
+      return { message: "予期しないエラーが発生しました" };
+    }
   }
 
   // 認証成功時はトップページへ

--- a/src/app/login/login.module.css
+++ b/src/app/login/login.module.css
@@ -63,3 +63,15 @@
   color: #0070f3;
   cursor: pointer;
 }
+
+.error {
+  color: #d93025;
+  background-color: #fce8e6;
+  border: 1px solid #fad2cf;
+  padding: 12px;
+  border-radius: 4px;
+  margin-bottom: 20px;
+  font-size: 14px;
+  font-weight: bold;
+  text-align: center;
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,20 +1,45 @@
-import { login } from "./actions";
+"use client";
+
+import { useActionState } from "react";
+import { login, type ActionState } from "./actions";
 import styles from "./login.module.css";
 
+// フォームの初期状態
+const initialState: ActionState = {
+  message: "",
+};
+
 export default function Login() {
+  /**
+   * state: サーバーから返ってきたデータ（messageなど）
+   * formAction: formのaction属性に渡す関数
+   * pending: 送信中かどうか（true/false）
+   */
+  const [state, formAction, pending] = useActionState(login, initialState);
+
   return (
     <>
       <div className={styles.login}>
         <h1 className={styles.title}>ログイン</h1>
-        {/* actionを追加 */}
-        <form action={login} className={styles.loginForm}>
+
+        <form action={formAction} className={styles.loginForm}>
+          {/* エラーメッセージがある場合のみ表示 */}
+          {state.message && <p className={styles.error}>{state.message}</p>}
+
           <label className={styles.label}>メールアドレス</label>
           <input type="email" name="username" className={styles.input} placeholder="メールアドレスを入力" required />
+
           <label className={styles.label}>パスワード</label>
           <input type="password" name="password" className={styles.input} placeholder="パスワードを入力" required />
-          <button type="submit" className={styles.button}>
-            ログイン
+
+          <button
+            type="submit"
+            className={styles.button}
+            disabled={pending} // 送信中はボタンを押せないようにする
+          >
+            {pending ? "ログイン中..." : "ログイン"}
           </button>
+
           <p className={styles.register}>
             アカウントをお持ちでない方は
             <span className={styles.registerLink}>新規登録</span>


### PR DESCRIPTION
## 概要
close #36 
Supabase Authを使ったログイン機能を実装しました。

## 実施事項
* ログインフォームとSupabase認証（Server Actions）の紐付け
* 認証成功時のトップページへのリダイレクト処理
* `useActionState`を用いたエラーハンドリングの実装（エラー時にメッセージを表示）
* Supabaseのエラーコード（`invalid_credentials`等）に応じたメッセージの出し分け
* 入力フォームの必須チェック（required）の追加
* 送信中（pending）のボタン非活性化処理の追加

## 確認事項
- [x] テストユーザーでログインし、トップページへ遷移することを確認
- [x] パスワード間違いの際、画面上に適切なエラーメッセージが表示されることを確認
- [x] ログイン処理中、ボタンが「ログイン中...」となり連打できないことを確認