### PR TITLE
feat: Next.js v16のProxy機能を用いた認証ガード（リダイレクト制御）の実装

### DIFF
--- a/src/libs/supabase/proxy.ts
+++ b/src/libs/supabase/proxy.ts
@@ -1,0 +1,67 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function updateSession(request: NextRequest) {
+  let response = NextResponse.next({
+    request: {
+      headers: request.headers,
+    },
+  });
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !key) {
+    console.error("❌ Supabase環境変数が読み込めていません。 .env.local を確認してください。");
+    return response;
+  }
+
+  const supabase = createServerClient(url, key, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
+        response = NextResponse.next({
+          request: {
+            headers: request.headers,
+          },
+        });
+        cookiesToSet.forEach(({ name, value, options }) => response.cookies.set(name, value, options));
+      },
+    },
+  });
+
+  // ユーザー取得
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // --- デバッグログ ---
+  // console.log("Proxy updateSession Running");
+  // console.log("Path:", request.nextUrl.pathname);
+  // console.log("User:", user ? user.email : "Guest");
+
+  const pathname = request.nextUrl.pathname;
+
+  // 未認証制限
+  const isProtected =
+    pathname.startsWith("/articles/new") || /^\/articles\/[^/]+\/edit/.test(pathname) || pathname.startsWith("/users/");
+
+  if (!user && isProtected) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/login";
+    return NextResponse.redirect(url);
+  }
+
+  // 認証済み制限
+  const isAuthPage = pathname.startsWith("/login") || pathname.startsWith("/signup");
+  if (user && isAuthPage) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/";
+    return NextResponse.redirect(url);
+  }
+
+  return response;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,10 @@
+import { type NextRequest } from "next/server";
+import { updateSession } from "./libs/supabase/proxy";
+
+export async function proxy(request: NextRequest) {
+  return await updateSession(request);
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"],
+};


### PR DESCRIPTION
## 概要（何をしたPRか）

Next.js v16 の新しいファイル規約である `proxy.ts` を導入し、Supabase Auth を利用したサーバーサイドの認証ガード（リダイレクト制御）を実装しました。

## 関連Issue

Closes #38 

## 変更内容

- **Next.js v16 `proxy.ts` による認証制御の導入**: サーバーサイドでリクエストをインターセプトし、認証状態に応じたルーティング制御を行う `src/proxy.ts` を実装。
- **認証ガード・ロジックの実装**: `src/libs/supabase/proxy.ts` にて `getUser()` を使用し、アクセス制限が必要なページへの認証チェックを実装。
- **未認証ユーザーへのアクセス制限**: ログインしていないユーザーが以下の保護ルートにアクセスした際、自動的に `/login` へリダイレクトする処理を追加。
    - `/articles/new`
    - `/articles/[id]/edit`
    - `/users/[id]`
- **ログイン済みユーザーの制御**: すでに認証済みのユーザーが `/login` や `/signup` にアクセスした際、トップページ（`/`）へリダイレクトする処理を追加。
- **SSR環境でのセッション維持**: Supabase SSR クライアントの `cookies` 操作を最適化し、サーバーサイドでのセッション更新が確実に行われるよう実装。

## 影響範囲

- [ ] UIのみ
- [x] APIあり
- [x] DB/Supabaseあり
- [x] インフラ/Vercelあり

## 動作確認方法

1. ログアウト状態で `http://localhost:3000/articles/new` にアクセスし、`/login` へリダイレクトされることを確認。
2. ログイン状態で `http://localhost:3000/login` にアクセスし、トップページ `/` へ戻されることを確認。
3. 保護ルート（`/articles/new` 等）にログイン状態でアクセスし、正常にページが表示されることを確認。

## テストケース

- [x] ログインができる
- [ ] バリデーションが発火する
- [x] 正常系の確認ができる（認証状態に応じた適切なページアクセスとリダイレクト）
- [x] 異常系の確認ができる（未認証時の保護ルートアクセス拒否）

## スクリーンショット（UI変更がある場合）

## レビューしてほしい部分や不安な部分

- `src/proxy.ts` の matcher 設定において、静的ファイルや画像を除外する正規表現に漏れがないか。
- `getUser()` を用いたサーバーサイド検証の実装において、セキュリティ面での懸念がないか。

---

## 確認事項

- [x] 作業ブランチで `git pull origin main` を実行した
- [x] コンフリクトがあればローカルで解決した（不明なら相談する）