### PR TITLE
feat: ヘッダーの認証/未認証切り替え機能の実装

### DIFF
--- a/src/component/Header/index.module.css
+++ b/src/component/Header/index.module.css
@@ -18,6 +18,15 @@
   cursor: pointer;
   background-color: transparent;
   color: #333333;
+
+  /* Linkとbuttonの見た目を揃える */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  font-family: inherit;
+  box-sizing: border-box;
+  line-height: 1;
 }
 
 .buttonPrimary {

--- a/src/component/Header/index.tsx
+++ b/src/component/Header/index.tsx
@@ -1,23 +1,68 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import styles from "./index.module.css";
+import Link from "next/link";
+import { useRouter, usePathname } from "next/navigation";
+import { createClient } from "@/libs/supabase/client";
 
 const Header = () => {
-  // supabaseの認証状態をここで取得し、useStateにセットする想定
   const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const router = useRouter();
+  // 今のURLのパスを取得する
+  const pathname = usePathname();
+  const supabase = createClient();
+
+  useEffect(() => {
+    const checkUser = async () => {
+      // セッション（ログイン状態）を取得
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      setIsAuthenticated(!!session);
+    };
+
+    // 画面が開いた時や、URLが変わった時にチェックを実行
+    checkUser();
+
+    // リアルタイム監視もセット
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setIsAuthenticated(!!session);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+    // pathname（URL）が変わるたびにこのuseEffectを再実行させる
+  }, [supabase.auth, pathname]);
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+    router.push("/login");
+    router.refresh();
+  };
 
   return (
     <header className={styles.header}>
       {!isAuthenticated ? (
         <>
-          <button className={styles.button}>ログイン</button>
-          <button className={`${styles.button} ${styles.buttonPrimary}`}>新規登録</button>
+          <Link href="/login" className={styles.button}>
+            ログイン
+          </Link>
+          <Link href="/signup" className={`${styles.button} ${styles.buttonPrimary}`}>
+            新規登録
+          </Link>
         </>
       ) : (
         <>
-          <button className={styles.button}>新規作成</button>
-          <button className={`${styles.button} ${styles.buttonPrimary}`}>ログアウト</button>
+          <Link href="/articles/new" className={styles.button}>
+            新規作成
+          </Link>
+          <button onClick={handleLogout} className={`${styles.button} ${styles.buttonPrimary}`}>
+            ログアウト
+          </button>
         </>
       )}
     </header>

--- a/src/libs/supabase/client.ts
+++ b/src/libs/supabase/client.ts
@@ -1,0 +1,9 @@
+import { createBrowserClient } from "@supabase/ssr";
+import { Database } from "@/types/supabase/type";
+
+export function createClient() {
+  return createBrowserClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+  );
+}


### PR DESCRIPTION
概要（何をしたPRか）
Supabaseの認証状態（ログイン/未ログイン）に応じて、ヘッダーの表示（ボタン・リンク）が切り替わるように実装しました。

関連Issue
Closes #66

変更内容
クライアントサイドでSupabaseを扱うための設定ファイルを追加（src/libs/supabase/client.ts）
ヘッダー（Header/index.tsx）にて、Supabaseのセッション状態を取得し、表示を切り替える処理を追加
画面遷移時にも状態が即座に切り替わるよう、usePathnameを用いて監視処理を実装
ログアウト機能を実装（ログアウト後は /login へリダイレクト）
<Link>と<button>で生じるレイアウトや高さのズレを解消するため、CSS（index.module.css）を調整

影響範囲
- [x] UIのみ（ヘッダーの表示変更）
- [ ] APIあり
- [x] DB/Supabaseあり（Supabase Authによるセッション管理）
- [ ] インフラ/Vercelあり

動作確認方法
未ログイン状態で画面を開き、ヘッダーに「ログイン」「新規登録」が表示されることを確認。
ログインを行い、ヘッダーが「新規作成」「ログアウト」に切り替わることを確認。
別の画面に遷移しても、ヘッダーの認証状態が正しく維持されていることを確認。
「ログアウト」をクリックし、ログアウト処理が完了してログイン画面へ遷移することを確認。

テストケース
- [x] 未ログイン時に「ログイン」「新規登録」ボタンが表示される
- [x] ログイン時に「新規作成」「ログアウト」ボタンが表示される
- [x] ログアウトボタン押下で正常にログアウトでき、ログイン画面にリダイレクトされる
- [x] 画面遷移（URL変更）時にもヘッダーの表示状態が即座に反映される