### PR TITLE
feat: 記事のタイトル検索機能の実装

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ export default async function Home({
 }) {
   const supabase = await createClient();
 
-  const { page } = await searchParams;
+  const { page, q } = await searchParams;
 
   const parsedPage = Number(page);
   const currentPage = isNaN(parsedPage) ? 1 : Math.max(1, parsedPage);
@@ -21,11 +21,7 @@ export default async function Home({
   const from = (currentPage - 1) * PAGE_SIZE;
   const to = from + PAGE_SIZE - 1;
 
-  const {
-    data: posts,
-    error,
-    count,
-  } = await supabase
+  let query = supabase
     .from("posts")
     .select(
       `
@@ -35,8 +31,14 @@ export default async function Home({
     `,
       { count: "exact" },
     )
-    .order("created_at", { ascending: false })
-    .range(from, to);
+    .order("created_at", { ascending: false });
+
+  // 検索キーワード(q)があれば、titleに部分一致する条件を追加
+  if (typeof q === "string" && q.trim() !== "") {
+    query = query.ilike("title", `%${q.trim()}%`);
+  }
+
+  const { data: posts, error, count } = await query.range(from, to);
 
   if (error) {
     return <div>データの取得に失敗しました</div>;
@@ -60,6 +62,12 @@ export default async function Home({
             timeAgo={new Date(post.created_at).toLocaleString("ja-JP")}
           />
         ))}
+        {/* 検索結果が0件だった時のメッセージを追加 */}
+        {posts?.length === 0 && (
+          <div style={{ textAlign: "center", width: "100%", gridColumn: "1 / -1", padding: "2rem" }}>
+            該当する記事が見つかりませんでした。
+          </div>
+        )}
       </section>
 
       <div className={styles.paginationArea}>

--- a/src/component/SearchBar/index.tsx
+++ b/src/component/SearchBar/index.tsx
@@ -1,10 +1,55 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import styles from "./index.module.css";
 
 const SearchBar = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // 今のURLに検索キーワード(q)があれば初期値としてセットする
+  const initialQuery = searchParams.get("q") || "";
+  const [query, setQuery] = useState(initialQuery);
+
+  // 検索を実行する関数
+  const handleSearch = () => {
+    // 今のURLパラメーターを取得
+    const params = new URLSearchParams(searchParams.toString());
+
+    if (query.trim()) {
+      params.set("q", query.trim()); // キーワードがあればセット
+    } else {
+      params.delete("q"); // 空欄なら削除
+    }
+
+    // 検索したら1ページ目に戻したいのでpageパラメーターは消す
+    params.delete("page");
+
+    // 新しいURLに遷移
+    router.push(`/?${params.toString()}`);
+  };
+
+  // Enterキーを押した時にも検索が走るようにする
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleSearch();
+    }
+  };
+
   return (
     <div className={styles.container}>
-      <input type="text" className={styles.input} placeholder="検索したい記事を入力してください" />
-      <button className={styles.button}>検索</button>
+      <input
+        type="text"
+        className={styles.input}
+        placeholder="検索したい記事を入力してください"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={handleKeyDown}
+      />
+      <button className={styles.button} onClick={handleSearch}>
+        検索
+      </button>
     </div>
   );
 };


### PR DESCRIPTION
## 概要（何をしたPRか）

Home画面のサーチボックスから、記事のタイトルにキーワードが含まれるものを検索・絞り込みできるように実装しました。

## 関連Issue

Closes #46 

変更内容

- `src/component/SearchBar/index.tsx`
  - 入力した検索キーワードをURLパラメーター（`?q=キーワード`）に反映する処理を追加
  - Enterキー押下での検索実行に対応
- `src/app/page.tsx`
  - URLパラメーターから`q`を受け取り、Supabaseのクエリに `.ilike` を用いたタイトル部分一致検索を追加
  - 検索結果が0件だった場合のメッセージ表示を追加

## 影響範囲

- [x] UIのみ
- [ ] APIあり
- [x] DB/Supabaseあり
- [ ] インフラ/Vercelあり

## 動作確認方法

1. Home画面の検索バーに、存在する記事のタイトルの一部を入力して「検索」ボタン（またはEnterキー）を押す。
2. 該当する記事のみに一覧が絞り込まれ、URLに `?q=キーワード` が付与されることを確認する。
3. 存在しないキーワードで検索し、「該当する記事が見つかりませんでした。」と表示されることを確認する。

## テストケース

- [x] 検索ボタンクリックで正しい結果に絞り込まれる
- [x] Enterキー押下で正しい結果に絞り込まれる
- [x] 検索結果0件の時のメッセージが正しく表示される
- [x] 検索時、ページネーションが1ページ目にリセットされる（pageパラメーターの削除）